### PR TITLE
fix: dependencies for cuda-dev / run_depend

### DIFF
--- a/patches/package.xml
+++ b/patches/package.xml
@@ -12,7 +12,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>nvidia-cuda</build_depend>
+  <build_depend>nvidia-cuda-dev</build_depend>
   <build_depend>libopencv-dev</build_depend>
+
+  <run_depend>nvidia-cuda</run_depend>
+  <run_depend>libopencv-dev</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>rospy</test_depend>


### PR DESCRIPTION
add `nvidia-cuda-dev` to build_depend.
It also adds `run_depend` for runtime requirements.

from https://github.com/ros/rosdistro/pull/13718

This closes #1 