### PR TITLE
Remove cuda package from run_depend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,42 @@
 ## ROS release package for http://pjreddie.com/darknet/
 
 ## Setup
-Install CUDA from https://developer.nvidia.com/cuda-downloads
 
-Install ROS from http://wiki.ros.org/indigo/Installation/Ubuntu
+1. Install CUDA from https://developer.nvidia.com/cuda-downloads
 
-```
-apt-get install ros-indigo-darknet
-```
+  Please ensure cuda is available:
+
+  ```bash
+  $ nvidia-smi
+  Fri Oct  6 18:55:36 2017
+  +-----------------------------------------------------------------------------+
+  | NVIDIA-SMI 375.26                 Driver Version: 375.26                    |
+  |-------------------------------+----------------------+----------------------+
+  | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+  | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
+  |===============================+======================+======================|
+  |   0  GeForce GTX TIT...  Off  | 0000:02:00.0      On |                  N/A |
+  | 22%   34C    P8    19W / 250W |    589MiB / 12203MiB |      9%      Default |
+  +-------------------------------+----------------------+----------------------+
+  
+  +-----------------------------------------------------------------------------+
+  | Processes:                                                       GPU Memory |
+  |  GPU       PID  Type  Process name                               Usage      |
+  |=============================================================================|
+  |    0    117042    G   /usr/bin/X                                     369MiB |
+  |    0    118023    G   compiz                                         216MiB |
+  +-----------------------------------------------------------------------------+
+  ```
+
+2. Install ROS from http://wiki.ros.org/indigo/Installation/Ubuntu
+3. Install this package
+
+  ```bash
+  $ sudo apt-get install ros-indigo-darknet
+  ```
 
 ## Example
+
 ```
 roscd darknet
 darknet detect cfg/yolo.cfg weights/yolo.weights data/dog.jpg

--- a/patches/package.xml
+++ b/patches/package.xml
@@ -15,7 +15,6 @@
   <build_depend>nvidia-cuda-dev</build_depend>
   <build_depend>libopencv-dev</build_depend>
 
-  <run_depend>nvidia-cuda</run_depend>
   <run_depend>libopencv-dev</run_depend>
 
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
As following offline conversation with @k-okada, preparing cuda environment should be responsible to user side.
The changes on this pull request are:
- Remove `nvidia-cuda` from `run_depend`
- Add more detail about installing CUDA to README
